### PR TITLE
Refactor imports to use updated runtime module paths

### DIFF
--- a/galvatron/profile_hardware/profile_all2all.py
+++ b/galvatron/profile_hardware/profile_all2all.py
@@ -15,8 +15,8 @@ from typing import Tuple, List, Any
 import argparse
 
 import galvatron
-from galvatron.core.pipeline import PipelineParallel, PipeSequential
-from galvatron.core.comm_groups import gen_comm_groups
+from galvatron.core.runtime.pipeline import PipelineParallel, PipeSequential
+from galvatron.core.runtime.comm_groups import gen_comm_groups
 from galvatron.utils import read_json_config, write_json_config
 
 

--- a/galvatron/profile_hardware/profile_allreduce.py
+++ b/galvatron/profile_hardware/profile_allreduce.py
@@ -14,8 +14,8 @@ from typing import Tuple, List
 import argparse
 
 import galvatron
-from galvatron.core.pipeline import PipelineParallel, PipeSequential
-from galvatron.core.comm_groups import gen_comm_groups
+from galvatron.core.runtime.pipeline import PipelineParallel, PipeSequential
+from galvatron.core.runtime.comm_groups import gen_comm_groups
 from galvatron.utils import read_json_config, write_json_config
 
 

--- a/galvatron/profile_hardware/profile_p2p.py
+++ b/galvatron/profile_hardware/profile_p2p.py
@@ -14,8 +14,8 @@ from typing import Tuple, List
 import argparse
 
 import galvatron
-from galvatron.core.pipeline import PipelineParallel, PipeSequential
-from galvatron.core.comm_groups import gen_comm_groups
+from galvatron.core.runtime.pipeline import PipelineParallel, PipeSequential
+from galvatron.core.runtime.comm_groups import gen_comm_groups
 from galvatron.utils import read_json_config, write_json_config
 
 def init_method_constant(val):


### PR DESCRIPTION
This PR updates import statements in three files to reflect the new module structure under galvatron.core.runtime
