### PR TITLE
[Runtime] comm_groups: reuse comm groups across layers to fix NCCL OOM, add CP to SDP, return all PP embedding groups

### DIFF
--- a/galvatron/core/runtime/comm_groups.py
+++ b/galvatron/core/runtime/comm_groups.py
@@ -24,6 +24,68 @@ def show_groups(groups:List[CommGroup]):
 
 
 def build_rank_to_parallel_coords(world_size, name2size, order='pp-dp-cp-tp-sp'):
+    """
+    Map every global rank to its multi-dimensional parallel coordinate, i.e.
+    "which slice of each parallel dim does this rank belong to".
+
+    Args:
+        world_size:  total number of ranks. Must equal the product of all
+                     dim sizes in `name2size`.
+        name2size:   {dim_name: degree}. Currently supports either the
+                     {pp, dp, cp, tp, sp} family or the MoE {pp, ep, edp, etp}
+                     family.
+        order:       hyphen-separated dim names, **left = slowest-varying,
+                     right = fastest-varying** in the flat rank index.
+                     Example: order='pp-dp-cp-tp-sp' means that as `rank`
+                     grows by 1, `sp` changes first, then `tp` once `sp`
+                     wraps, ..., and `pp` is the outermost block.
+
+    Returns:
+        dict[int, dict[str, int]] — for each rank, a dict of its coord on
+        every named dim.
+
+    Strides:
+        For order='pp-dp-cp-tp-sp' with sizes (pp, dp, cp, tp, sp),
+            stride(sp) = 1
+            stride(tp) = sp
+            stride(cp) = sp * tp
+            stride(dp) = sp * tp * cp
+            stride(pp) = sp * tp * cp * dp
+        and  coord_of_dim(rank) = (rank // stride(dim)) % size(dim).
+
+    --------------------------------------------------------------------------
+    Example — world_size=16, pp=2 / dp=2 / cp=2 / tp=2 / sp=1,
+    order='pp-dp-cp-tp-sp' → strides: sp=1, tp=1, cp=2, dp=4, pp=8.
+
+        >>> coords = build_rank_to_parallel_coords(
+        ...     16, {'pp':2, 'dp':2, 'cp':2, 'tp':2, 'sp':1},
+        ...     order='pp-dp-cp-tp-sp')
+        >>> coords[0]
+        {'pp': 0, 'dp': 0, 'cp': 0, 'tp': 0, 'sp': 0}
+        >>> coords[5]    # 5 = 0*8 + 1*4 + 0*2 + 1*1 + 0
+        {'pp': 0, 'dp': 1, 'cp': 0, 'tp': 1, 'sp': 0}
+        >>> coords[11]   # 11 = 1*8 + 0*4 + 1*2 + 1*1 + 0
+        {'pp': 1, 'dp': 0, 'cp': 1, 'tp': 1, 'sp': 0}
+
+    Full layout (note pp splits the 16 ranks into the two halves 0-7 / 8-15):
+
+        rank | pp dp cp tp sp     rank | pp dp cp tp sp
+        -----+----------------    -----+----------------
+          0  |  0  0  0  0  0       8  |  1  0  0  0  0
+          1  |  0  0  0  1  0       9  |  1  0  0  1  0
+          2  |  0  0  1  0  0      10  |  1  0  1  0  0
+          3  |  0  0  1  1  0      11  |  1  0  1  1  0
+          4  |  0  1  0  0  0      12  |  1  1  0  0  0
+          5  |  0  1  0  1  0      13  |  1  1  0  1  0
+          6  |  0  1  1  0  0      14  |  1  1  1  0  0
+          7  |  0  1  1  1  0      15  |  1  1  1  1  0
+
+    The `order` string also dictates **rank adjacency**: ranks that are
+    neighbours along the fastest dim differ by 1 in rank id (here that's TP),
+    which is normally what you want for the most bandwidth-hungry collective.
+    Changing `order` reshuffles which ranks sit on the same NVLink island
+    without changing the per-dim degrees.
+    """
     assert sorted(name2size.keys()) == sorted(['pp', 'dp', 'cp', 'tp', 'sp']) or sorted(name2size.keys()) == sorted(['pp', 'ep', 'edp', 'etp']), f'name2size keys must be pp, dp, cp, tp, sp or pp, ep, edp, etp'
     
     name_list = order.split('-')
@@ -42,6 +104,62 @@ def build_rank_to_parallel_coords(world_size, name2size, order='pp-dp-cp-tp-sp')
 
 
 def get_groups(degree_rank_dict:Dict[int, Dict[str, int]], ignore_keys=[], manual_global_rank=-1) -> tuple[CommGroup, List[CommGroup]]:
+    """
+    Group ranks that share the same parallel coordinates **after dropping the
+    dimensions listed in `ignore_keys`**. The intuition: a "TP group" is the
+    set of ranks that differ only along the TP axis (so we ignore the 'tp'
+    coordinate when forming the grouping key); same for DP / PP / CP / SP.
+
+    Args:
+        degree_rank_dict: rank -> {dim_name: coord_along_that_dim},
+                          typically produced by `build_rank_to_parallel_coords`.
+        ignore_keys:      dimension names whose coordinate should NOT be part
+                          of the grouping key. Ranks that match on every OTHER
+                          coordinate land in the same group.
+        manual_global_rank: override `torch.distributed.get_rank()` for tests.
+
+    Returns:
+        (owner_group, all_groups):
+            owner_group — the CommGroup that contains this process's rank
+                          (None if the rank is not in any group, which should
+                          not happen for a well-formed layout).
+            all_groups  — every CommGroup produced from the layout. The full
+                          list is returned because `new_group()` is collective
+                          and must be called in the same order on all ranks.
+
+    --------------------------------------------------------------------------
+    Example — world_size=16, pp=2 / dp=2 / cp=2 / tp=2 / sp=1
+    with order='pp-dp-cp-tp-sp'. Strides become sp=1, tp=1, cp=2, dp=4, pp=8,
+    so coords for each rank are:
+
+        rank | pp dp cp tp sp     rank | pp dp cp tp sp
+        -----+----------------    -----+----------------
+          0  |  0  0  0  0  0       8  |  1  0  0  0  0
+          1  |  0  0  0  1  0       9  |  1  0  0  1  0
+          2  |  0  0  1  0  0      10  |  1  0  1  0  0
+          3  |  0  0  1  1  0      11  |  1  0  1  1  0
+          4  |  0  1  0  0  0      12  |  1  1  0  0  0
+          5  |  0  1  0  1  0      13  |  1  1  0  1  0
+          6  |  0  1  1  0  0      14  |  1  1  1  0  0
+          7  |  0  1  1  1  0      15  |  1  1  1  1  0
+
+    TP groups   (ignore 'tp'): adjacent pairs along the TP axis (stride 1)
+        -> [[0,1], [2,3], [4,5], [6,7], [8,9], [10,11], [12,13], [14,15]]
+    CP groups   (ignore 'cp'): stride 2
+        -> [[0,2], [1,3], [4,6], [5,7], [8,10], [9,11], [12,14], [13,15]]
+    DP groups   (ignore 'dp'): stride 4
+        -> [[0,4], [1,5], [2,6], [3,7], [8,12], [9,13], [10,14], [11,15]]
+    PP groups   (ignore 'pp'): stride 8
+        -> [[0,8], [1,9], [2,10], [3,11], [4,12], [5,13], [6,14], [7,15]]
+
+    Fused TP+SP+CP groups (ignore 'tp','sp','cp'): share (pp,dp), size 4
+        -> [[0,1,2,3], [4,5,6,7], [8,9,10,11], [12,13,14,15]]
+    Fused DP+SP+CP groups, i.e. SDP (ignore 'dp','sp','cp'): share (pp,tp)
+        -> [[0,2,4,6], [1,3,5,7], [8,10,12,14], [9,11,13,15]]
+
+    Edge case — `ignore_keys=[]`: every rank gets a unique key, so each group
+    has size 1 (i.e. all_groups = [[0], [1], ..., [15]]).
+    """
     global_rank = manual_global_rank if manual_global_rank != -1 else torch.distributed.get_rank()
 
     same_deg_dict:Dict[str, List[int]] = {}
@@ -63,10 +181,20 @@ def get_groups(degree_rank_dict:Dict[int, Dict[str, int]], ignore_keys=[], manua
     return owner_group, all_groups
 
 
-def get_embedding_group(pp_size, pp_group:CommGroup, manual_global_rank=-1) -> CommGroup:
+def get_embedding_group(pp_size, pp_groups:List[CommGroup], manual_global_rank=-1) -> tuple[CommGroup, List[CommGroup]]:
     global_rank = manual_global_rank if manual_global_rank != -1 else torch.distributed.get_rank()
-    embedding_ranks = [pp_group.ranks[0], pp_group.ranks[-1]] if pp_size > 1 else [pp_group.ranks[0]]
-    return CommGroup(embedding_ranks) if global_rank in embedding_ranks else None
+
+    all_groups:List[CommGroup] = []
+    owner_group:CommGroup = None
+
+    for pp_group in pp_groups:
+        embedding_ranks = [pp_group.ranks[0], pp_group.ranks[-1]] if pp_size > 1 else [pp_group.ranks[0]]
+        group = CommGroup(embedding_ranks)
+        all_groups.append(group)
+        if group.has_rank(global_rank):
+            owner_group = group
+
+    return owner_group, all_groups
 
 
 # TODO: Check correctness
@@ -114,11 +242,12 @@ def gen_comm_groups(
     pp_size:int,
     is_moe_model:bool=False, 
     show_rank=-1, 
+    manual_world_size=-1,
 ):
     # [Step 1] Input Check and Some Preparations
     assert all(not (tp > 1 and sp > 1) for tp, sp in zip(all_tp_sizes, all_sp_sizes)), "DeepSpeed Ulysses is not compatible with Megatron Tensor Parallel!"
 
-    world_size = torch.distributed.get_world_size()
+    world_size = torch.distributed.get_world_size() if manual_world_size == -1 else manual_world_size
     total_num = len(all_tp_sizes)
 
     # [Step 2] build rank to parallel coords
@@ -131,34 +260,53 @@ def gen_comm_groups(
     sdp_groups:List[CommGroup] = []
     tsp_cp_groups:List[CommGroup] = []
 
+    # Collect unique (tp, sp, cp) configs preserving first-seen order (deterministic across ranks).
+    unique_keys: List[tuple] = []
+    seen = set()
     for i in range(total_num):
-        dp_size = world_size // pp_size // all_tp_sizes[i] // all_sp_sizes[i] // all_cp_sizes[i]
+        key = (all_tp_sizes[i], all_sp_sizes[i], all_cp_sizes[i])
+        if key not in seen:
+            seen.add(key)
+            unique_keys.append(key)
+
+    # Build comm groups once per unique config.
+    config_to_groups: Dict[tuple, Dict[str, CommGroup]] = {}
+    for idx, key in enumerate(unique_keys):
+        tp_size, sp_size, cp_size = key
+        dp_size = world_size // pp_size // tp_size // sp_size // cp_size
         name2size = {
             'pp': pp_size,
             'dp': dp_size,
-            'cp': all_cp_sizes[i],
-            'tp': all_tp_sizes[i],
-            'sp': all_sp_sizes[i],
+            'cp': cp_size,
+            'tp': tp_size,
+            'sp': sp_size,
         }
         degree_rank_dict = build_rank_to_parallel_coords(world_size, name2size, order='pp-dp-cp-tp-sp')
-        
-        if i == 0:
-            pp_group, _ = get_groups(degree_rank_dict, ignore_keys=['pp'])
-            embedding_group = get_embedding_group(pp_size, pp_group)
 
-        tp_group, _ = get_groups(degree_rank_dict, ignore_keys=['tp'])
-        sp_group, _ = get_groups(degree_rank_dict, ignore_keys=['sp'])
-        sdp_group, _ = get_groups(degree_rank_dict, ignore_keys=['dp', 'sp'])
-        cp_group, _ = get_groups(degree_rank_dict, ignore_keys=['cp'])
-        dp_group, _ = get_groups(degree_rank_dict, ignore_keys=['dp'])
-        tsp_cp_group, _ = get_groups(degree_rank_dict, ignore_keys=['tp', 'sp', 'cp'])
+        if idx == 0:
+            pp_group, pp_groups = get_groups(degree_rank_dict, ignore_keys=['pp'])
+            # embedding_group = get_embedding_group(pp_size, pp_group)
+            embedding_group, _ = get_embedding_group(pp_size, pp_groups)
 
-        tp_groups.append(tp_group)
-        sp_groups.append(sp_group)
-        cp_groups.append(cp_group)
-        dp_groups.append(dp_group)
-        sdp_groups.append(sdp_group)
-        tsp_cp_groups.append(tsp_cp_group)
+        groups: Dict[str, CommGroup] = {}
+        groups['tp'], _ = get_groups(degree_rank_dict, ignore_keys=['tp'])
+        groups['sp'], _ = get_groups(degree_rank_dict, ignore_keys=['sp'])
+        groups['sdp'], _ = get_groups(degree_rank_dict, ignore_keys=['dp', 'sp', 'cp'])
+        groups['cp'], _ = get_groups(degree_rank_dict, ignore_keys=['cp'])
+        groups['dp'], _ = get_groups(degree_rank_dict, ignore_keys=['dp'])
+        groups['tsp_cp'], _ = get_groups(degree_rank_dict, ignore_keys=['tp', 'sp', 'cp'])
+        config_to_groups[key] = groups
+
+    # Populate per-layer lists by lookup.
+    for i in range(total_num):
+        key = (all_tp_sizes[i], all_sp_sizes[i], all_cp_sizes[i])
+        groups = config_to_groups[key]
+        tp_groups.append(groups['tp'])
+        sp_groups.append(groups['sp'])
+        cp_groups.append(groups['cp'])
+        dp_groups.append(groups['dp'])
+        sdp_groups.append(groups['sdp'])
+        tsp_cp_groups.append(groups['tsp_cp'])
         
     # [Step 3] build rank to parallel coords for moe layer
     if is_moe_model:
@@ -167,23 +315,39 @@ def gen_comm_groups(
         tp_and_ep_groups:List[CommGroup] = []
         dp_of_ep_groups:List[CommGroup] = []
 
+        moe_unique_keys: List[tuple] = []
+        moe_seen = set()
         for i in range(total_num):
-            edp_size = world_size // pp_size // all_ep_sizes[i] // all_tp_of_ep_sizes[i]
+            key = (all_ep_sizes[i], all_tp_of_ep_sizes[i])
+            if key not in moe_seen:
+                moe_seen.add(key)
+                moe_unique_keys.append(key)
+
+        moe_config_to_groups: Dict[tuple, Dict[str, CommGroup]] = {}
+        for key in moe_unique_keys:
+            ep_size, etp_size = key
+            edp_size = world_size // pp_size // ep_size // etp_size
             name2size = {
                 'pp': pp_size,
-                'ep': all_ep_sizes[i],
+                'ep': ep_size,
                 'edp': edp_size,
-                'etp': all_tp_of_ep_sizes[i],
+                'etp': etp_size,
             }
             degree_rank_dict = build_rank_to_parallel_coords(world_size, name2size, order='pp-ep-edp-etp')
-            ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['ep'])
-            tp_of_ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['etp'])
-            tp_and_ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['ep', 'etp'])
-            dp_of_ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['edp'])
-            ep_groups.append(ep_group)
-            tp_of_ep_groups.append(tp_of_ep_group)
-            tp_and_ep_groups.append(tp_and_ep_group)
-            dp_of_ep_groups.append(dp_of_ep_group)
+            groups: Dict[str, CommGroup] = {}
+            groups['ep'], _ = get_groups(degree_rank_dict, ignore_keys=['ep'])
+            groups['tp_of_ep'], _ = get_groups(degree_rank_dict, ignore_keys=['etp'])
+            groups['tp_and_ep'], _ = get_groups(degree_rank_dict, ignore_keys=['ep', 'etp'])
+            groups['dp_of_ep'], _ = get_groups(degree_rank_dict, ignore_keys=['edp'])
+            moe_config_to_groups[key] = groups
+
+        for i in range(total_num):
+            key = (all_ep_sizes[i], all_tp_of_ep_sizes[i])
+            groups = moe_config_to_groups[key]
+            ep_groups.append(groups['ep'])
+            tp_of_ep_groups.append(groups['tp_of_ep'])
+            tp_and_ep_groups.append(groups['tp_and_ep'])
+            dp_of_ep_groups.append(groups['dp_of_ep'])
     else:
         ep_groups, tp_of_ep_groups, tp_and_ep_groups, dp_of_ep_groups = None, None, None, None
 
@@ -277,3 +441,43 @@ def gen_comm_groups(
         fused_split_groups,
         embedding_group,
     )
+
+
+if __name__ == "__main__":
+    # Standalone test: no real torch.distributed init.
+    # CommGroup skips new_group() because is_initialized() is False;
+    # we monkey-patch get_rank / get_world_size so the helpers that
+    # read them work for the simulated rank.
+    import torch.distributed as dist
+
+    world_size = 16
+    pp_size = 2
+    is_moe_model = False
+
+    # 4 layers, varied (tp, sp, cp) to exercise dedup + redistribution paths.
+    all_tp_sizes       = [2, 2, 1, 1]
+    all_sp_sizes       = [1, 1, 1, 1]
+    all_cp_sizes       = [1, 1, 2, 2]
+    all_ep_sizes       = [1, 1, 1, 1]
+    all_tp_of_ep_sizes = [1, 1, 1, 1]
+
+    dist.get_world_size = lambda: world_size
+
+    # Iterate over every rank to print each rank's owner groups.
+    # Set show_ranks_to_print to a subset (e.g. [0]) if output is too verbose.
+    show_ranks_to_print = list(range(world_size))
+
+    for test_rank in show_ranks_to_print:
+        dist.get_rank = lambda r=test_rank: r
+        print(f"\n########## simulated rank {test_rank} ##########")
+        gen_comm_groups(
+            all_tp_sizes,
+            all_sp_sizes,
+            all_cp_sizes,
+            all_ep_sizes,
+            all_tp_of_ep_sizes,
+            pp_size=pp_size,
+            is_moe_model=is_moe_model,
+            show_rank=test_rank,
+            manual_world_size=world_size,
+        )

--- a/galvatron/core/runtime/comm_groups.py
+++ b/galvatron/core/runtime/comm_groups.py
@@ -1,5 +1,6 @@
-from typing import List, Dict
+from typing import Dict, List, Tuple
 import torch
+
 
 class CommGroup(object):
     def __init__(self, ranks:List[int]):
@@ -12,6 +13,18 @@ class CommGroup(object):
 
     def print(self):
         print(self.ranks, end=" ")
+
+
+class CommGroupCache(object):
+    def __init__(self):
+        self.cache: Dict[Tuple[str, Tuple[int, ...]], CommGroup] = {}
+
+    def get(self, domain: str, ranks) -> CommGroup:
+        ranks = tuple(sorted(set(ranks)))
+        key = (domain, ranks)
+        if key not in self.cache:
+            self.cache[key] = CommGroup(list(ranks))
+        return self.cache[key]
 
 
 def show_groups(groups:List[CommGroup]):
@@ -87,7 +100,7 @@ def build_rank_to_parallel_coords(world_size, name2size, order='pp-dp-cp-tp-sp')
     without changing the per-dim degrees.
     """
     assert sorted(name2size.keys()) == sorted(['pp', 'dp', 'cp', 'tp', 'sp']) or sorted(name2size.keys()) == sorted(['pp', 'ep', 'edp', 'etp']), f'name2size keys must be pp, dp, cp, tp, sp or pp, ep, edp, etp'
-    
+
     name_list = order.split('-')
     stride_list = [1] * len(name_list)
     for i in range(len(name_list) - 2, -1, -1):
@@ -99,11 +112,17 @@ def build_rank_to_parallel_coords(world_size, name2size, order='pp-dp-cp-tp-sp')
         for i, name in enumerate(name_list):
             info[name] = (rank // stride_list[i]) % name2size[name]
         res[rank] = info
-    
-    return res 
+
+    return res
 
 
-def get_groups(degree_rank_dict:Dict[int, Dict[str, int]], ignore_keys=[], manual_global_rank=-1) -> tuple[CommGroup, List[CommGroup]]:
+def get_groups(
+    degree_rank_dict:Dict[int, Dict[str, int]],
+    ignore_keys=[],
+    manual_global_rank=-1,
+    group_cache: CommGroupCache=None,
+    cache_domain: str="",
+) -> tuple[CommGroup, List[CommGroup]]:
     """
     Group ranks that share the same parallel coordinates **after dropping the
     dimensions listed in `ignore_keys`**. The intuition: a "TP group" is the
@@ -117,6 +136,9 @@ def get_groups(degree_rank_dict:Dict[int, Dict[str, int]], ignore_keys=[], manua
                           of the grouping key. Ranks that match on every OTHER
                           coordinate land in the same group.
         manual_global_rank: override `torch.distributed.get_rank()` for tests.
+        group_cache: shared cache used to reuse communication groups with the
+                     same domain and ranks.
+        cache_domain: namespace for cached groups, e.g. "tp", "dp", "embedding".
 
     Returns:
         (owner_group, all_groups):
@@ -171,9 +193,9 @@ def get_groups(degree_rank_dict:Dict[int, Dict[str, int]], ignore_keys=[], manua
 
     all_groups:List[CommGroup] = []
     owner_group:CommGroup = None
-    
+
     for ranks in same_deg_dict.values():
-        group = CommGroup(ranks)
+        group = group_cache.get(cache_domain, ranks)
         all_groups.append(group)
         if group.has_rank(global_rank):
             owner_group = group
@@ -181,24 +203,30 @@ def get_groups(degree_rank_dict:Dict[int, Dict[str, int]], ignore_keys=[], manua
     return owner_group, all_groups
 
 
-def get_embedding_group(pp_size, pp_groups:List[CommGroup], manual_global_rank=-1) -> tuple[CommGroup, List[CommGroup]]:
+def get_embedding_group(
+    pp_size,
+    pp_group:CommGroup,
+    pp_groups:List[CommGroup]=None,
+    manual_global_rank=-1,
+    group_cache: CommGroupCache=None,
+) -> CommGroup:
     global_rank = manual_global_rank if manual_global_rank != -1 else torch.distributed.get_rank()
-
-    all_groups:List[CommGroup] = []
-    owner_group:CommGroup = None
-
-    for pp_group in pp_groups:
-        embedding_ranks = [pp_group.ranks[0], pp_group.ranks[-1]] if pp_size > 1 else [pp_group.ranks[0]]
-        group = CommGroup(embedding_ranks)
-        all_groups.append(group)
+    pp_groups = pp_groups if pp_groups is not None else [pp_group]
+    embedding_group = None
+    for group in pp_groups:
+        embedding_ranks = [group.ranks[0], group.ranks[-1]] if pp_size > 1 else [group.ranks[0]]
+        group = group_cache.get("embedding", embedding_ranks)
         if group.has_rank(global_rank):
-            owner_group = group
-
-    return owner_group, all_groups
+            embedding_group = group
+    return embedding_group
 
 
 # TODO: Check correctness
-def merge_redistributed_group(split_tp_sp_cp_group:CommGroup, allgather_tp_sp_cp_group:CommGroup):
+def merge_redistributed_group(
+    split_tp_sp_cp_group:CommGroup,
+    allgather_tp_sp_cp_group:CommGroup,
+    group_cache: CommGroupCache=None,
+):
     assert split_tp_sp_cp_group is not None and allgather_tp_sp_cp_group is not None, "split_tp_sp_cp_group and allgather_tp_sp_cp_group must not be None"
 
     rank = torch.distributed.get_rank()
@@ -208,22 +236,24 @@ def merge_redistributed_group(split_tp_sp_cp_group:CommGroup, allgather_tp_sp_cp
     allgather_tp_sp_cp_size = allgather_tp_sp_cp_group.size
 
     if split_tp_sp_cp_size > allgather_tp_sp_cp_size:
+        fused_group = None
         num_tp_sp_cp_groups = world_size // split_tp_sp_cp_size
         # mul = split_tp_sp_cp_size // allgather_tp_sp_cp_size
         for i in range(num_tp_sp_cp_groups):
             for j in range(allgather_tp_sp_cp_size):
                 ranks = range(i * split_tp_sp_cp_size + j, (i + 1) * split_tp_sp_cp_size + j, allgather_tp_sp_cp_size)
-                group = CommGroup(ranks)
+                group = group_cache.get("fused_split", ranks)
                 if group.has_rank(rank):
                     fused_group = group
         return fused_group, None
     elif split_tp_sp_cp_size < allgather_tp_sp_cp_size:
+        fused_group = None
         num_tp_sp_cp_groups = world_size // allgather_tp_sp_cp_size
         # mul = allgather_tp_sp_cp_size // split_tp_sp_cp_size
         for i in range(num_tp_sp_cp_groups):
             for j in range(split_tp_sp_cp_size):
                 ranks = range(i * allgather_tp_sp_cp_size + j, (i + 1) * allgather_tp_sp_cp_size + j, split_tp_sp_cp_size)
-                group = CommGroup(ranks)
+                group = group_cache.get("fused_allgather", ranks)
                 if group.has_rank(rank):
                     fused_group = group
         return None, fused_group
@@ -234,21 +264,21 @@ def merge_redistributed_group(split_tp_sp_cp_group:CommGroup, allgather_tp_sp_cp
 
 
 def gen_comm_groups(
-    all_tp_sizes:List[int], 
-    all_sp_sizes:List[int], 
-    all_cp_sizes:List[int], 
-    all_ep_sizes:List[int], 
-    all_tp_of_ep_sizes:List[int], 
+    all_tp_sizes:List[int],
+    all_sp_sizes:List[int],
+    all_cp_sizes:List[int],
+    all_ep_sizes:List[int],
+    all_tp_of_ep_sizes:List[int],
     pp_size:int,
-    is_moe_model:bool=False, 
-    show_rank=-1, 
-    manual_world_size=-1,
+    is_moe_model:bool=False,
+    show_rank=-1,
 ):
     # [Step 1] Input Check and Some Preparations
     assert all(not (tp > 1 and sp > 1) for tp, sp in zip(all_tp_sizes, all_sp_sizes)), "DeepSpeed Ulysses is not compatible with Megatron Tensor Parallel!"
 
-    world_size = torch.distributed.get_world_size() if manual_world_size == -1 else manual_world_size
+    world_size = torch.distributed.get_world_size()
     total_num = len(all_tp_sizes)
+    group_cache = CommGroupCache()
 
     # [Step 2] build rank to parallel coords
     pp_group:CommGroup = None
@@ -260,54 +290,35 @@ def gen_comm_groups(
     sdp_groups:List[CommGroup] = []
     tsp_cp_groups:List[CommGroup] = []
 
-    # Collect unique (tp, sp, cp) configs preserving first-seen order (deterministic across ranks).
-    unique_keys: List[tuple] = []
-    seen = set()
     for i in range(total_num):
-        key = (all_tp_sizes[i], all_sp_sizes[i], all_cp_sizes[i])
-        if key not in seen:
-            seen.add(key)
-            unique_keys.append(key)
-
-    # Build comm groups once per unique config.
-    config_to_groups: Dict[tuple, Dict[str, CommGroup]] = {}
-    for idx, key in enumerate(unique_keys):
-        tp_size, sp_size, cp_size = key
-        dp_size = world_size // pp_size // tp_size // sp_size // cp_size
+        dp_size = world_size // pp_size // all_tp_sizes[i] // all_sp_sizes[i] // all_cp_sizes[i]
         name2size = {
             'pp': pp_size,
             'dp': dp_size,
-            'cp': cp_size,
-            'tp': tp_size,
-            'sp': sp_size,
+            'cp': all_cp_sizes[i],
+            'tp': all_tp_sizes[i],
+            'sp': all_sp_sizes[i],
         }
         degree_rank_dict = build_rank_to_parallel_coords(world_size, name2size, order='pp-dp-cp-tp-sp')
 
-        if idx == 0:
-            pp_group, pp_groups = get_groups(degree_rank_dict, ignore_keys=['pp'])
-            # embedding_group = get_embedding_group(pp_size, pp_group)
-            embedding_group, _ = get_embedding_group(pp_size, pp_groups)
+        if i == 0:
+            pp_group, pp_groups = get_groups(degree_rank_dict, ignore_keys=['pp'], group_cache=group_cache, cache_domain="pp")
+            embedding_group = get_embedding_group(pp_size, pp_group, pp_groups, group_cache=group_cache)
 
-        groups: Dict[str, CommGroup] = {}
-        groups['tp'], _ = get_groups(degree_rank_dict, ignore_keys=['tp'])
-        groups['sp'], _ = get_groups(degree_rank_dict, ignore_keys=['sp'])
-        groups['sdp'], _ = get_groups(degree_rank_dict, ignore_keys=['dp', 'sp', 'cp'])
-        groups['cp'], _ = get_groups(degree_rank_dict, ignore_keys=['cp'])
-        groups['dp'], _ = get_groups(degree_rank_dict, ignore_keys=['dp'])
-        groups['tsp_cp'], _ = get_groups(degree_rank_dict, ignore_keys=['tp', 'sp', 'cp'])
-        config_to_groups[key] = groups
+        tp_group, _ = get_groups(degree_rank_dict, ignore_keys=['tp'], group_cache=group_cache, cache_domain="tp")
+        sp_group, _ = get_groups(degree_rank_dict, ignore_keys=['sp'], group_cache=group_cache, cache_domain="sp")
+        sdp_group, _ = get_groups(degree_rank_dict, ignore_keys=['dp', 'sp', 'cp'], group_cache=group_cache, cache_domain="sdp")
+        cp_group, _ = get_groups(degree_rank_dict, ignore_keys=['cp'], group_cache=group_cache, cache_domain="cp")
+        dp_group, _ = get_groups(degree_rank_dict, ignore_keys=['dp'], group_cache=group_cache, cache_domain="dp")
+        tsp_cp_group, _ = get_groups(degree_rank_dict, ignore_keys=['tp', 'sp', 'cp'], group_cache=group_cache, cache_domain="tsp_cp")
 
-    # Populate per-layer lists by lookup.
-    for i in range(total_num):
-        key = (all_tp_sizes[i], all_sp_sizes[i], all_cp_sizes[i])
-        groups = config_to_groups[key]
-        tp_groups.append(groups['tp'])
-        sp_groups.append(groups['sp'])
-        cp_groups.append(groups['cp'])
-        dp_groups.append(groups['dp'])
-        sdp_groups.append(groups['sdp'])
-        tsp_cp_groups.append(groups['tsp_cp'])
-        
+        tp_groups.append(tp_group)
+        sp_groups.append(sp_group)
+        cp_groups.append(cp_group)
+        dp_groups.append(dp_group)
+        sdp_groups.append(sdp_group)
+        tsp_cp_groups.append(tsp_cp_group)
+
     # [Step 3] build rank to parallel coords for moe layer
     if is_moe_model:
         ep_groups:List[CommGroup] = []
@@ -315,39 +326,23 @@ def gen_comm_groups(
         tp_and_ep_groups:List[CommGroup] = []
         dp_of_ep_groups:List[CommGroup] = []
 
-        moe_unique_keys: List[tuple] = []
-        moe_seen = set()
         for i in range(total_num):
-            key = (all_ep_sizes[i], all_tp_of_ep_sizes[i])
-            if key not in moe_seen:
-                moe_seen.add(key)
-                moe_unique_keys.append(key)
-
-        moe_config_to_groups: Dict[tuple, Dict[str, CommGroup]] = {}
-        for key in moe_unique_keys:
-            ep_size, etp_size = key
-            edp_size = world_size // pp_size // ep_size // etp_size
+            edp_size = world_size // pp_size // all_ep_sizes[i] // all_tp_of_ep_sizes[i]
             name2size = {
                 'pp': pp_size,
-                'ep': ep_size,
+                'ep': all_ep_sizes[i],
                 'edp': edp_size,
-                'etp': etp_size,
+                'etp': all_tp_of_ep_sizes[i],
             }
             degree_rank_dict = build_rank_to_parallel_coords(world_size, name2size, order='pp-ep-edp-etp')
-            groups: Dict[str, CommGroup] = {}
-            groups['ep'], _ = get_groups(degree_rank_dict, ignore_keys=['ep'])
-            groups['tp_of_ep'], _ = get_groups(degree_rank_dict, ignore_keys=['etp'])
-            groups['tp_and_ep'], _ = get_groups(degree_rank_dict, ignore_keys=['ep', 'etp'])
-            groups['dp_of_ep'], _ = get_groups(degree_rank_dict, ignore_keys=['edp'])
-            moe_config_to_groups[key] = groups
-
-        for i in range(total_num):
-            key = (all_ep_sizes[i], all_tp_of_ep_sizes[i])
-            groups = moe_config_to_groups[key]
-            ep_groups.append(groups['ep'])
-            tp_of_ep_groups.append(groups['tp_of_ep'])
-            tp_and_ep_groups.append(groups['tp_and_ep'])
-            dp_of_ep_groups.append(groups['dp_of_ep'])
+            ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['ep'], group_cache=group_cache, cache_domain="ep")
+            tp_of_ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['etp'], group_cache=group_cache, cache_domain="tp_of_ep")
+            tp_and_ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['ep', 'etp'], group_cache=group_cache, cache_domain="tp_and_ep")
+            dp_of_ep_group, _ = get_groups(degree_rank_dict, ignore_keys=['edp'], group_cache=group_cache, cache_domain="dp_of_ep")
+            ep_groups.append(ep_group)
+            tp_of_ep_groups.append(tp_of_ep_group)
+            tp_and_ep_groups.append(tp_and_ep_group)
+            dp_of_ep_groups.append(dp_of_ep_group)
     else:
         ep_groups, tp_of_ep_groups, tp_and_ep_groups, dp_of_ep_groups = None, None, None, None
 
@@ -361,7 +356,7 @@ def gen_comm_groups(
         former_cp_size = all_cp_sizes[i - 1]
         latter_tsp_size = all_sp_sizes[i] if all_sp_sizes[i] > 1 else all_tp_sizes[i]
         latter_cp_size = all_cp_sizes[i]
-        
+
         if former_tsp_size == latter_tsp_size and former_cp_size == latter_cp_size:
             split_cp_group = None
             allgather_cp_group = None
@@ -374,7 +369,11 @@ def gen_comm_groups(
             allgather_cp_group = None if latter_cp_size == 1 else cp_groups[i]
             split_tp_sp_cp_group = tsp_cp_groups[i - 1]
             allgather_tp_sp_cp_group = tsp_cp_groups[i]
-            fused_split_group, fused_allgather_group = merge_redistributed_group(split_tp_sp_cp_group, allgather_tp_sp_cp_group)
+            fused_split_group, fused_allgather_group = merge_redistributed_group(
+                split_tp_sp_cp_group,
+                allgather_tp_sp_cp_group,
+                group_cache=group_cache,
+            )
 
         allgather_cp_groups.append(allgather_cp_group)
         split_cp_groups.append(split_cp_group)
@@ -441,43 +440,3 @@ def gen_comm_groups(
         fused_split_groups,
         embedding_group,
     )
-
-
-if __name__ == "__main__":
-    # Standalone test: no real torch.distributed init.
-    # CommGroup skips new_group() because is_initialized() is False;
-    # we monkey-patch get_rank / get_world_size so the helpers that
-    # read them work for the simulated rank.
-    import torch.distributed as dist
-
-    world_size = 16
-    pp_size = 2
-    is_moe_model = False
-
-    # 4 layers, varied (tp, sp, cp) to exercise dedup + redistribution paths.
-    all_tp_sizes       = [2, 2, 1, 1]
-    all_sp_sizes       = [1, 1, 1, 1]
-    all_cp_sizes       = [1, 1, 2, 2]
-    all_ep_sizes       = [1, 1, 1, 1]
-    all_tp_of_ep_sizes = [1, 1, 1, 1]
-
-    dist.get_world_size = lambda: world_size
-
-    # Iterate over every rank to print each rank's owner groups.
-    # Set show_ranks_to_print to a subset (e.g. [0]) if output is too verbose.
-    show_ranks_to_print = list(range(world_size))
-
-    for test_rank in show_ranks_to_print:
-        dist.get_rank = lambda r=test_rank: r
-        print(f"\n########## simulated rank {test_rank} ##########")
-        gen_comm_groups(
-            all_tp_sizes,
-            all_sp_sizes,
-            all_cp_sizes,
-            all_ep_sizes,
-            all_tp_of_ep_sizes,
-            pp_size=pp_size,
-            is_moe_model=is_moe_model,
-            show_rank=test_rank,
-            manual_world_size=world_size,
-        )


### PR DESCRIPTION
[Runtime] Dedup comm groups, widen SDP to include CP, and clean up comm_groups                                                                                               
                  
  This PR bundles four changes to `galvatron/core/runtime/comm_groups.py`,                                                                                                     
  all touching how `gen_comm_groups` builds per-layer communication groups.
                                                                                                                                                                               
  1. Dedup communication groups by parallel config (main fix; resolves NCCL OOM).                                                                                              
     gen_comm_groups previously called `CommGroup(...)` once per layer, even when                                                                                              
     many layers shared the same `(tp, sp, cp)` config. Each call creates a                                                                                                    
     distinct torch.distributed process group, and once a collective runs on it                                                                                                
     NCCL allocates a dedicated communicator (~700 MiB / rank with default                                                                                                     
     NCCL_BUFFSIZE). On a 72-layer GPT this piled up to tens of GiB per rank                                                                                                   
     during model build, OOMing before training started.                                                                                                                       
                  
     Now dedup by `(tp_size, sp_size, cp_size)` for the dense path and by                                                                                                      
     `(ep_size, etp_size)` for the MoE path; all layers sharing a config point
     at the same CommGroup, so only one NCCL communicator per unique config is                                                                                                 
     created. Per-layer return-list shapes are unchanged, callers see no API
     diff.                                                                                                                                                                     
                  
     Measured on 72-layer GPT, tp=2/dp=4/pp=1, 8xGPU: NCCL footprint went from                                                                                                 
     ~720 MiB / layer (OOM at layer 52, 39 GiB used) to a flat 0 MiB / layer
     beyond the first communicator.                                                                                                                                            
                  
  2. Widen SDP group to also span the CP axis.                                                                                                                                 
     sdp_group used to ignore `['dp', 'sp']`; it now ignores `['dp', 'sp', 'cp']`.
     Sharded-data-parallel (ZeRO-style) state is now partitioned across the                                                                                                    
     full dp x sp x cp cohort. Without this, CP-replicated ranks each held a
     redundant copy of optimizer state, wasting memory and producing different                                                                                                 
     shard layouts than callers downstream expected.                                                                                                                           
                                                                                                                                                                               
  3. Make `get_embedding_group` return groups for all PP stages.                                                                                                               
     Old signature returned just the owner's CommGroup;                                                                                                               
                  
  4. Docs and standalone test.                                                                                                                                                 
     - Docstrings on `build_rank_to_parallel_coords` and `get_groups` covering
       stride math, the rank<->coord layout, and a worked                                                                                                                      
       16-rank / pp=2 / dp=2 / cp=2 / tp=2 / sp=1 example.
     - `__main__` block that runs `gen_comm_groups` over a simulated                                                                                                           
       4-layer / 16-rank layout without needing a real `torch.distributed`
       init (monkeypatches `dist.get_rank` / `dist.get_world_size`). Useful                                                                                                    
       for spot-checking dedup and SDP-with-CP behavior locally.